### PR TITLE
fix: use git SSH instead of HTTPS

### DIFF
--- a/blackman
+++ b/blackman
@@ -27,7 +27,7 @@
 VERSION="blackman v0.5.14"
 
 # url blackarch repository
-REMOTE_REPO="https://github.com/BlackArch/blackarch.git"
+REMOTE_REPO="git@github.com:BlackArch/blackarch.git"
 
 # local base directory for blackman
 LOCAL_BLACKMAN="${HOME}/.blackman"


### PR DESCRIPTION
## What?

Encourage `blackman` to use SSH instead of HTTPS for `git` (github) operations.

## Why?

 - Github no longer accepts account passwords when authenticating git operations.
 - Github requires token-based or ssh-key authentication. 

## Anything Else? 

Even though this repo might not be fully maintained, it is still useful and by adding these changes, we keep track of what needs to be done for a future potential re-writing of the tool 

## References

 - [About Authentication to Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github)